### PR TITLE
Fix csdm.save() data serialization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,13 +12,6 @@ Whats new!
   Now you can directly plot CSDM objects as an argument to the above matplotlib
   methods.
 
-Other changes
-'''''''''''''
-
-- Added ``dict()`` as an alias to the ``to_dict()`` method for all objects.
-- Added an alias of the ``cp.plot()`` function to the CSDM object as the
-  ``plot()`` method.
-
 
 v0.2.2
 ------
@@ -34,6 +27,9 @@ Other changes
 '''''''''''''
 
 - Add a new diffusion tensor MRI dataset to the example gallery.
+- Added ``dict()`` as an alias to the ``to_dict()`` method for all objects.
+- Added an alias of the ``cp.plot()`` function to the CSDM object as the
+  ``plot()`` method.
 
 v0.2.1
 ------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,39 @@
 
-v0.3.0.dev0
------------
+Upcoming additions and changes
+------------------------------
 
-- Added `dict()` as an alias to the `to_dict()` method for all objects.
+Whats new!
+''''''''''
+
+- Support for ``matplotlib.pyplot`` functions from ``CSDM`` objects.
+    - ``plot``
+    - ``imshow``
+
+  Now you can directly plot CSDM objects as an argument to the above matplotlib
+  methods.
+
+Other changes
+'''''''''''''
+
+- Added ``dict()`` as an alias to the ``to_dict()`` method for all objects.
 - Added an alias of the ``cp.plot()`` function to the CSDM object as the
   ``plot()`` method.
 
+
+v0.2.2
+------
+
+Bug fixes
+'''''''''
+
+- Fixed bug where the metadata from the ``csdm.application`` key was not serialized
+  to the file when using ``csdm.save()`` method.
+
 v0.2.1
 ------
+
+Whats new!
+''''''''''
 
 - Add ``reciprocal_coordinates()`` and ``reciprocal_increment()`` methods to the
   `LinearDimension` class.
@@ -17,33 +43,40 @@ v0.2.1
 v0.2.0
 ------
 
-- Fixed a bug in ``cp.plot()`` method.
-- Added following methods to the `CSDM` class:
-   - ``__eq__()`` for all class
-   - ``__add__()`` = Adds two csdm object.
-   - ``__iadd__()`` = Adds two csdm objects in-place.
-   - ``__sub__()`` = Subtrace two csdm objects.
-   - ``__isub__()`` = Subtrace two csdm objects in-place.
-   - ``__mul__()`` = Multiply the components of the csdm object by a scalar.
-   - ``__imul__()`` = Multiply the components of the csdm object by a scalar in-place.
-   - ``__truvdiv__()`` = Divide the components of the csdm object by a scalar.
-   - ``__itruediv__()`` = Divide the components of the csdm object by a scalar
-     in-place.
-   - ``split()`` = Split the dependent-variables into individual csdm objects.
+Whats new!
+''''''''''
+
+- Added following methods to the ``CSDM`` class:
+    - ``__eq__()`` for all class
+    - ``__add__()`` = Adds two csdm object.
+    - ``__iadd__()`` = Adds two csdm objects in-place.
+    - ``__sub__()`` = Subtrace two csdm objects.
+    - ``__isub__()`` = Subtrace two csdm objects in-place.
+    - ``__mul__()`` = Multiply the components of the csdm object by a scalar.
+    - ``__imul__()`` = Multiply the components of the csdm object by a scalar in-place.
+    - ``__truvdiv__()`` = Divide the components of the csdm object by a scalar.
+    - ``__itruediv__()`` = Divide the components of the csdm object by a scalar
+      in-place.
+    - ``split()`` = Split the dependent-variables into individual csdm objects.
 
 - Support for Numpy dimension reduction functions
     - ``sum()``: Sum along a given dimension.
     - ``prod()``: Product along a given dimension.
 
 - Support for Numpy ufunc functions:
-   - ``sin``, ``cos``, ``tan``, ``arcsin``, ``arccos``, ``arctan``, ``sinh``, ``cosh``,
-     ``tanh``, ``arcsinh``, ``arccosh``, ``arctanh``, ``exp``, ``exp2``, ``log``,
-     ``log2``, ``log10``, ``expm1``, ``log1p``, ``negative``, ``positive``, ``square``,
-     ``absolute``, ``fabs``, ``rint``, ``sign``, ``conj``, ``conjugate``, ``sqrt``,
-     ``cbrt``, ``reciprocal``
+    - ``sin``, ``cos``, ``tan``, ``arcsin``, ``arccos``, ``arctan``, ``sinh``, ``cosh``,
+      ``tanh``, ``arcsinh``, ``arccosh``, ``arctanh``, ``exp``, ``exp2``, ``log``,
+      ``log2``, ``log10``, ``expm1``, ``log1p``, ``negative``, ``positive``, ``square``,
+      ``absolute``, ``fabs``, ``rint``, ``sign``, ``conj``, ``conjugate``, ``sqrt``,
+      ``cbrt``, ``reciprocal``
 
 - Added apodization functions.
-   - ``sin``, ``cos``, ``tan``, ``arcsin``, ``arccos``, ``arctan``, ``exp``
+    - ``sin``, ``cos``, ``tan``, ``arcsin``, ``arccos``, ``arctan``, ``exp``
+
+Bug fixes
+'''''''''
+
+- Fixed a bug in ``cp.plot()`` method.
 
 v0.1.5
 ------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,12 @@ Bug fixes
 - Fixed bug where the metadata from the ``csdm.application`` key was not serialized
   to the file when using ``csdm.save()`` method.
 
+
+Other changes
+'''''''''''''
+
+- Add a new diffusion tensor MRI dataset to the example gallery.
+
 v0.2.1
 ------
 

--- a/csdmpy/__init__.py
+++ b/csdmpy/__init__.py
@@ -34,7 +34,7 @@ __credits__ = ["Deepansh J. Srivastava"]
 __license__ = "BSD License"
 __maintainer__ = "Deepansh J. Srivastava"
 __status__ = "Development"
-__version__ = "0.3.0.dev0"
+__version__ = "0.2.2"
 
 __all__ = [
     "parse_dict",

--- a/csdmpy/csdm.py
+++ b/csdmpy/csdm.py
@@ -937,6 +937,10 @@ class CSDM:
 
         if self.description.strip() != "":
             dictionary["description"] = self.description
+
+        if self.application != {}:
+            dictionary["application"] = self.application
+
         dictionary["dimensions"] = []
         dictionary["dependent_variables"] = []
 

--- a/csdmpy/dependent_variables/external.py
+++ b/csdmpy/dependent_variables/external.py
@@ -74,20 +74,7 @@ class ExternalDataset(BaseDependentVariable):
 
     def __eq__(self, other):
         """Overrides the default implementation"""
-        check = [
-            self._name == other._name,
-            self._unit == other._unit,
-            self._quantity_name == other._quantity_name,
-            self._encoding == other._encoding,
-            self._numeric_type == other._numeric_type,
-            self._quantity_type == other._quantity_type,
-            self._component_labels == other._component_labels,
-            self._description == other._description,
-            self._application == other._application,
-            np.allclose(self._components, other._components),
-            self._sparse_sampling == other._sparse_sampling,
-            self._components_url == other._components_url,
-        ]
+        check = [super().__eq__(other), self._sparse_sampling == other._sparse_sampling]
         if False in check:
             return False
         return True

--- a/csdmpy/dependent_variables/internal.py
+++ b/csdmpy/dependent_variables/internal.py
@@ -68,19 +68,7 @@ class InternalDataset(BaseDependentVariable):
 
     def __eq__(self, other):
         """Overrides the default implementation"""
-        check = [
-            self._name == other._name,
-            self._unit == other._unit,
-            self._quantity_name == other._quantity_name,
-            self._encoding == other._encoding,
-            self._numeric_type == other._numeric_type,
-            self._quantity_type == other._quantity_type,
-            self._component_labels == other._component_labels,
-            self._description == other._description,
-            self._application == other._application,
-            np.allclose(self._components, other._components),
-            self._sparse_sampling == other._sparse_sampling,
-        ]
+        check = [super().__eq__(other), self._sparse_sampling == other._sparse_sampling]
         if False in check:
             return False
         return True

--- a/csdmpy/dimensions/base.py
+++ b/csdmpy/dimensions/base.py
@@ -19,6 +19,17 @@ class BaseDimension:
         self._application = application
         self._label = label
 
+    def __eq__(self, other):
+        """Check if two objects are equal"""
+        check = [
+            self._description == other._description,
+            self._application == other._application,
+            self._label == other._label,
+        ]
+        if False in check:
+            return False
+        return True
+
     @property
     def label(self):
         r"""Label associated with the dimension."""

--- a/csdmpy/dimensions/labeled.py
+++ b/csdmpy/dimensions/labeled.py
@@ -51,9 +51,7 @@ class LabeledDimension(BaseDimension):
             check = [
                 self._count == other._count,
                 np.all(self._labels == other._labels),
-                self._label == other._label,
-                self._description == other._description,
-                self._application == other._application,
+                super().__eq__(other),
             ]
             if np.all(check):
                 return True

--- a/csdmpy/dimensions/linear.py
+++ b/csdmpy/dimensions/linear.py
@@ -87,16 +87,7 @@ class LinearDimension(BaseQuantitativeDimension):
                 self._increment == other._increment,
                 self._complex_fft == other._complex_fft,
                 self.reciprocal == other.reciprocal,
-                # super class
-                self._coordinates_offset == other._coordinates_offset,
-                self._origin_offset == other._origin_offset,
-                self._quantity_name == other._quantity_name,
-                self._period == other._period,
-                self._label == other._label,
-                self._description == other._description,
-                self._application == other._application,
-                self._unit == other._unit,
-                self._equivalencies == other._equivalencies,
+                super().__eq__(other),
             ]
             if np.all(check):
                 return True

--- a/csdmpy/dimensions/monotonic.py
+++ b/csdmpy/dimensions/monotonic.py
@@ -80,16 +80,7 @@ class MonotonicDimension(BaseQuantitativeDimension):
                 self._count == other._count,
                 np.all(self._coordinates == other._coordinates),
                 self.reciprocal == other.reciprocal,
-                # super class
-                self._coordinates_offset == other._coordinates_offset,
-                self._origin_offset == other._origin_offset,
-                self._quantity_name == other._quantity_name,
-                self._period == other._period,
-                self._label == other._label,
-                self._description == other._description,
-                self._application == other._application,
-                self._unit == other._unit,
-                self._equivalencies == other._equivalencies,
+                super().__eq__(other),
             ]
             if np.all(check):
                 return True

--- a/csdmpy/dimensions/quantitative.py
+++ b/csdmpy/dimensions/quantitative.py
@@ -71,11 +71,9 @@ class BaseQuantitativeDimension(BaseDimension):
             self._origin_offset == other._origin_offset,
             self._quantity_name == other._quantity_name,
             self._period == other._period,
-            self._label == other._label,
-            self._description == other._description,
-            self._application == other._application,
             self._unit == other._unit,
             self._equivalencies == other._equivalencies,
+            super().__eq__(other),
         ]
         if False in check:
             return False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,8 +137,8 @@ compatible with Numpy.
     startFromScratch/interacting_with_csdmpy_objects
     startFromScratch/save_dataset
     startFromScratch/A fun example
-    changelog
     referenceAPI
+    changelog
 
 ----
 

--- a/tests/csdm_test.py
+++ b/tests/csdm_test.py
@@ -96,6 +96,7 @@ def test_csdm():
             "read_only": True,
             "tags": ["1", "2", "3"],
             "description": "Enough with the tests",
+            "application": {"csdmpy": "Some day"},
             "dimensions": [],
             "dependent_variables": [],
         }

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+
+import csdmpy as cp
+
+
+def setup():
+    csdm = cp.new()
+    dimension1 = cp.as_dimension(np.arange(10))
+    dimension2 = cp.as_dimension(np.arange(20))
+    data = cp.as_dependent_variable(np.random.rand(20, 10))
+
+    csdm.add_dimension(dimension1)
+    csdm.add_dimension(dimension2)
+    csdm.add_dependent_variable(data)
+
+    return csdm
+
+
+def test_application():
+
+    csdm1 = setup()
+    csdm1.application = {"test": "root"}
+    csdm1.dimensions[0].application = {"test": "d0"}
+    csdm1.dimensions[0].reciprocal.application = {"test": "reciprocal-d0"}
+    csdm1.dimensions[1].application = {"test": "d1"}
+    csdm1.dimensions[1].reciprocal.application = {"test": "reciprocal-d1"}
+    csdm1.dependent_variables[0].application = {"test": "dv0"}
+
+    csdm1.dependent_variables[0].encoding = "base64"
+    csdm1.save("csdm1.csdf")
+
+    csdm1_test = cp.load("csdm1.csdf", application=True)
+
+    assert csdm1_test == csdm1


### PR DESCRIPTION
The PR fixes issue #10, where the metadata from the `csdm.application` key is not serialized to file with the `csdm.save()` method.

The PR also fixes the missing `csdm.application` key from the `csdm.data_structure` output.