### PR TITLE
fix bug when assigning DimensionList/DependentVariableList to csdm obj

### DIFF
--- a/csdmpy/csdm.py
+++ b/csdmpy/csdm.py
@@ -139,21 +139,23 @@ class CSDM:
 
         self._dimensions = DimensionList([])
         if "dimensions" in kwargs_keys:
-            if not isinstance(kwargs["dimensions"], list):
+            if not isinstance(kwargs["dimensions"], (list, DimensionList)):
                 t_ = type(kwargs["dimensions"])
                 raise ValueError(
-                    f"A list of valid Dimension objects or equivalent dictionary "
-                    f"objects is required, found {t_}"
+                    "A list of valid Dimension or equivalent dictionary objects is "
+                    f"required, found {t_}."
                 )
             _ = [self.dimensions.append(item) for item in kwargs["dimensions"]]
 
         self._dependent_variables = DependentVariableList([])
         if "dependent_variables" in kwargs_keys:
             t_ = type(kwargs["dependent_variables"])
-            if not isinstance(kwargs["dependent_variables"], list):
+            if not isinstance(
+                kwargs["dependent_variables"], (list, DependentVariableList)
+            ):
                 raise ValueError(
-                    f"A list of valid DependentVariable objects or equivalent "
-                    f"dictionary objects is required, found {t_}"
+                    "A list of valid DependentVariable or equivalent dictionary "
+                    f"objects is required, found {t_}."
                 )
             for item in kwargs["dependent_variables"]:
                 if isinstance(item, dict):
@@ -380,7 +382,7 @@ class CSDM:
         return -self.__sub__(other)
 
     def __isub__(self, other):
-        """Subtract two objects in-lace (y-=x). See __sub__ for details. """
+        """Subtract two objects in-lace (y-=x). See __sub__ for details."""
         return self.__ifunction__("__isub__", "-", other)
 
     def __mul__(self, other):
@@ -702,7 +704,7 @@ class CSDM:
 
     @property
     def filename(self):
-        """Local file address of the current file. """
+        """Local file address of the current file."""
         return self._filename
 
     # Numpy - like property

--- a/tests/csdm_new_test.py
+++ b/tests/csdm_new_test.py
@@ -30,10 +30,10 @@ def test_csdm_new():
 
 
 def test_bad_csdm():
-    error = "A list of valid Dimension objects or equivalent dictionary"
+    error = "A list of valid Dimension or equivalent dictionary objects"
     with pytest.raises(ValueError, match=f".*{error}.*"):
         cp.CSDM(dimensions="blah")
 
-    error = "A list of valid DependentVariable objects or equivalent dictionary"
+    error = "A list of valid DependentVariable or equivalent dictionary objects"
     with pytest.raises(ValueError, match=f".*{error}.*"):
         cp.CSDM(dependent_variables="blah")

--- a/tests/csdm_test.py
+++ b/tests/csdm_test.py
@@ -592,6 +592,16 @@ def test_to_list():
     assert np.allclose(dv_1, out)
 
 
+def test_new_from_old_csdm():
+    old_test = get_test_2d(int)[1]
+    new_test = cp.CSDM(
+        dimensions=old_test.dimensions, dependent_variables=old_test.dependent_variables
+    )
+    assert old_test.x == new_test.x
+    assert old_test.y == new_test.y
+    assert id(old_test.x) != id(new_test.x)
+
+
 # def test_argmin_max():
 #     out, new_test = get_test_2d(float)
 #     assert np.allclose(np.argmax(out), np.argmax(new_test))


### PR DESCRIPTION
Closes  #45 

```py
new_test = cp.CSDM(
    dimensions=old_test.dimensions, 
    dependent_variables=old_test.dependent_variables
)
```
will not raise error.