### PR TITLE
Bug fix for physicalType object serialization.

### DIFF
--- a/csdmpy/dependent_variable/__init__.py
+++ b/csdmpy/dependent_variable/__init__.py
@@ -544,7 +544,7 @@ class DependentVariable:
         Raises:
             NotImplementedError: When assigning a value.
         """
-        return self.subtype.quantity_name
+        return str(self.subtype.quantity_name)
 
     @quantity_name.setter
     def quantity_name(self, value=""):

--- a/csdmpy/dependent_variable/base_class.py
+++ b/csdmpy/dependent_variable/base_class.py
@@ -136,7 +136,7 @@ class BaseDependentVariable:
     @property
     def quantity_name(self):
         """Return quantity name associated with the physical quantity."""
-        return deepcopy(self._quantity_name)
+        return deepcopy(str(self._quantity_name))
 
     @quantity_name.setter
     def quantity_name(self, value=""):

--- a/csdmpy/dimension/__init__.py
+++ b/csdmpy/dimension/__init__.py
@@ -640,7 +640,7 @@ class Dimension:
             AttributeError: For `labeled` dimensions.
             NotImplementedError: When assigning a value.
         """
-        return self.subtype.quantity_name
+        return str(self.subtype.quantity_name)
 
     @quantity_name.setter
     def quantity_name(self, value):

--- a/csdmpy/dimension/quantitative.py
+++ b/csdmpy/dimension/quantitative.py
@@ -113,7 +113,7 @@ class BaseQuantitativeDimension(BaseDimension):
     @property
     def quantity_name(self):
         """Quantity name associated with this dimension."""
-        return deepcopy(self._quantity_name)
+        return deepcopy(str(self._quantity_name))
 
     @quantity_name.setter
     def quantity_name(self, value):

--- a/tests/dimension_test.py
+++ b/tests/dimension_test.py
@@ -681,3 +681,12 @@ def test_as_dimension():
     error = "Cannot convert a 2 dimensional array to a Dimension object."
     with pytest.raises(ValueError, match=".*{0}.*".format(error)):
         cp.as_dimension(np.arange(100).reshape(10, 10))
+
+
+def test_dimension_scale():
+    """Test for unit physical type in astropy>=4.0"""
+    dim = cp.LinearDimension(count=10, increment="1m")
+    dim2 = dim / 2.4
+    assert np.allclose(dim2.coordinates.value, np.arange(10) / 2.4)
+    assert dim2.quantity_name == "length"
+    assert type(dim2.quantity_name) == str


### PR DESCRIPTION
closes #42 

```py
dim = cp.LinearDimension(count=10, increment="1m")
dim2 = dim / 2.4
assert type(dim2.quantity_name) == str
```

Ensure the `quantity_name` is a string. From Astropy 4.0 and higher, the `physical_type` attribute is a `PhysicalType` object. The PR converts it to a string.