### PR TITLE
djs/Copy `np.frombuffer` data when loading

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Bugfix
 - Bugfix in serializing csdm #54
 - You can multiply CSDM objects by a scalar to the right (`csdm * scalar`). The fix
   now allows the multiplication of CSDM objects by a scalar to the left (`scalar * csdm`). #62
+- Bugfix where csdm objects `.csdfe` files were immutable.
 
 v0.5.0
 ------

--- a/csdmpy/dependent_variable/decoder.py
+++ b/csdmpy/dependent_variable/decoder.py
@@ -50,6 +50,8 @@ class Decoder:
     def decode_raw(components, dtype, component_len=None):
         """Read components form a binary buffer"""
         components = np.frombuffer(components, dtype=dtype)
+        if not components.flags["WRITEABLE"]:
+            components = components.copy()
         size = int(components.size / component_len)
         components = components.reshape(component_len, size)
         return components


### PR DESCRIPTION
The buffer data from the `.csdfe` file is a view of the original binary dataset, which is immutable. The PR copies the buffer data before converting it to a csdm object.