### PR TITLE
update unit attributes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ Feature
 
 - ``cp.join`` function to join multiple CSDM objects with same dimensions into
   one CSDM object with multiple dependent variables.
+- Ability to update dimension attribute units using the ``.to(unit, update_attrs=True)``
+  function. The default is the current behavior with ``update_attrs=False``
 
 v0.6.0
 ------

--- a/csdmpy/dimension/__init__.py
+++ b/csdmpy/dimension/__init__.py
@@ -789,7 +789,7 @@ class Dimension:
         """
         return self.subtype.is_quantitative()
 
-    def to(self, unit="", equivalencies=None):
+    def to(self, unit="", equivalencies=None, update_attrs=False):
         r"""Convert the coordinates along the dimension to the unit, `unit`.
 
         This method is a wrapper of the `to` method from the
@@ -805,13 +805,15 @@ class Dimension:
             [10.  10.5 11.  11.5 12.  12.5 13.  13.5 14.  14.5] mT
 
         Args:
-            `unit` : A string containing a unit with the same dimensionality as the
+            unit : A string containing a unit with the same dimensionality as the
                      coordinates along the dimension.
+            equivalencies: Convert to equivalent units
+            update_attrs: Update attribute units if equivalencies is None.
 
         Raises:
             AttributeError: For `labeled` dimensions.
         """
-        self.subtype.to(unit, equivalencies)
+        self.subtype.to(unit, equivalencies, update_attrs)
 
     def copy(self):
         """Return a copy of the Dimension object."""

--- a/csdmpy/dimension/quantitative.py
+++ b/csdmpy/dimension/quantitative.py
@@ -180,6 +180,8 @@ class BaseQuantitativeDimension(BaseDimension):
 
     def update_attribute_units(self, attrs, unit):
         """Update instance attribute units"""
+        if self.type == "monotonic":
+            attrs += ["_coordinates"]
         for item in attrs:
             if hasattr(self, item):
                 value = getattr(self, item)

--- a/csdmpy/dimension/quantitative.py
+++ b/csdmpy/dimension/quantitative.py
@@ -34,6 +34,8 @@ class BaseQuantitativeDimension(BaseDimension):
         "_equivalencies",
     )
 
+    unit_attributes = ["increment", "coordinates_offset", "origin_offset", "period"]
+
     def __init__(
         self,
         description="",
@@ -159,9 +161,13 @@ class BaseQuantitativeDimension(BaseDimension):
         """
         return True
 
-    def to(self, unit="", equivalencies=None):
+    def to(self, unit="", equivalencies=None, update_attrs=False):
         """Convert the unit to given value `unit`."""
         unit = validate(unit, "unit", str)
+
+        if update_attrs and equivalencies is None:
+            self.update_attribute_units(self.unit_attributes, unit)
+
         if equivalencies is None:
             self._unit = ScalarQuantity(unit, self._unit).quantity.unit
             self._equivalent_unit = None
@@ -171,6 +177,13 @@ class BaseQuantitativeDimension(BaseDimension):
         # self._unit = ScalarQuantity(unit).quantity.unit
         self._equivalent_unit = ScalarQuantity(unit).quantity.unit
         self._equivalencies = equivalencies
+
+    def update_attribute_units(self, attrs, unit):
+        """Update instance attribute units"""
+        for item in attrs:
+            if hasattr(self, item):
+                value = getattr(self, item)
+                setattr(self, item, value.to(unit))
 
 
 # =========================================================================== #

--- a/csdmpy/utils.py
+++ b/csdmpy/utils.py
@@ -219,7 +219,7 @@ def type_error(types, attr, value):
 
 def _axis_label(label, unit=None):
     """Return a formatted label with units."""
-    return f"{label} / ({unit})" if unit not in [None, ""] else label
+    return f"{label} / ({unit})" if str(unit) not in [None, ""] else label
 
 
 def _get_dictionary(*arg, **kwargs):

--- a/tests/dimension_test.py
+++ b/tests/dimension_test.py
@@ -707,7 +707,7 @@ def test_dimension_scale():
     assert type(dim2.quantity_name) is str
 
 
-def test_attribute_unit_update():
+def test_attribute_unit_update_linear():
     """Test attribute units"""
     d1 = cp.as_dimension(
         np.arange(100) + 10, unit="Hz", origin_offset="135 MHz", period="235 Hz"
@@ -737,3 +737,25 @@ def test_attribute_unit_update():
     assert str(d2.coordinates_offset.unit) == unitless
     assert str(d2.origin_offset.unit) == unitless
     assert str(d2.period.unit) == unitless
+
+
+def test_attribute_unit_update_monotonic():
+    """Test attribute units"""
+    d1 = cp.as_dimension([1, 3, 6, 10, 20, 100], unit="A", origin_offset="1.1 A")
+
+    d2 = d1 * cp.ScalarQuantity("ohm")
+
+    unit1 = str(u.Unit("A ohm"))
+
+    assert str(d2.coordinates.unit) == unit1
+    assert str(d2.origin_offset.unit) == unit1
+
+    # convert to unitless without attribute unit updates
+    d2.to("V")
+    assert str(d2.origin_offset.unit) == unit1
+
+    # convert to unitless with attribute unit update
+    unit2 = str(u.Unit("V"))
+    d2.to("V", update_attrs=True)
+    assert str(d2.coordinates.unit) == unit2
+    assert str(d2.origin_offset.unit) == unit2

--- a/tests/dimension_test.py
+++ b/tests/dimension_test.py
@@ -705,3 +705,35 @@ def test_dimension_scale():
     assert np.allclose(dim2.coordinates.value, np.arange(10) / 2.4)
     assert dim2.quantity_name == "length"
     assert type(dim2.quantity_name) is str
+
+
+def test_attribute_unit_update():
+    """Test attribute units"""
+    d1 = cp.as_dimension(
+        np.arange(100) + 10, unit="Hz", origin_offset="135 MHz", period="235 Hz"
+    )
+
+    d2 = d1 * cp.ScalarQuantity("s")
+
+    Hz_s_unit = str(u.Unit("Hz s"))
+    MHz_s_unit = str(u.Unit("MHz s"))
+
+    assert str(d2.increment.unit) == Hz_s_unit
+    assert str(d2.coordinates_offset.unit) == Hz_s_unit
+    assert str(d2.origin_offset.unit) == MHz_s_unit
+    assert str(d2.period.unit) == Hz_s_unit
+
+    # convert to unitless without attribute unit updates
+    d2.to("")
+    assert str(d2.increment.unit) == Hz_s_unit
+    assert str(d2.coordinates_offset.unit) == Hz_s_unit
+    assert str(d2.origin_offset.unit) == MHz_s_unit
+    assert str(d2.period.unit) == Hz_s_unit
+
+    # convert to unitless with attribute unit update
+    unitless = str(u.Unit(""))
+    d2.to("", update_attrs=True)
+    assert str(d2.increment.unit) == unitless
+    assert str(d2.coordinates_offset.unit) == unitless
+    assert str(d2.origin_offset.unit) == unitless
+    assert str(d2.period.unit) == unitless


### PR DESCRIPTION
Update the dimension attribute unit using the `to(unit, update_attrs=True)` function. The default is the current behavior with `update_attrs=False`

**Example**
```py
    d1 = cp.as_dimension(
        np.arange(100) + 10, unit="Hz", origin_offset="135 MHz", period="235 Hz"
    )

    d2 = d1 * cp.ScalarQuantity("s")

    Hz_s_unit = str(u.Unit("Hz s"))
    MHz_s_unit = str(u.Unit("MHz s"))

    assert str(d2.increment.unit) == Hz_s_unit
    assert str(d2.coordinates_offset.unit) == Hz_s_unit
    assert str(d2.origin_offset.unit) == MHz_s_unit
    assert str(d2.period.unit) == Hz_s_unit

    # convert to unitless without attribute unit updates
    d2.to("")
    assert str(d2.increment.unit) == Hz_s_unit
    assert str(d2.coordinates_offset.unit) == Hz_s_unit
    assert str(d2.origin_offset.unit) == MHz_s_unit
    assert str(d2.period.unit) == Hz_s_unit

    # convert to unitless with attribute unit update
    unitless = str(u.Unit(""))
    d2.to("", update_attrs=True)
    assert str(d2.increment.unit) == unitless
    assert str(d2.coordinates_offset.unit) == unitless
    assert str(d2.origin_offset.unit) == unitless
    assert str(d2.period.unit) == unitless
```